### PR TITLE
Add lines to TokeiResult type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -10,6 +10,7 @@ export interface TokeiResult {
     code: number;
     comments: number;
     stats: TokeiStat[];
+    lines: number;
 }
 export default function tokei(paths: string[] | string, exclude?: string[] | string): Promise<{
     [language: string]: TokeiResult;


### PR DESCRIPTION
The actual return value looks like this:

```
  [ 'Svg',
    { blanks: 5,
      code: 8261,
      comments: 12,
      stats: [Array],
      lines: 8278 } ],
```

This change makes the types match the implementation.

Fixes #1